### PR TITLE
Add assert to check that firebase config is present

### DIFF
--- a/addon/services/firebase.ts
+++ b/addon/services/firebase.ts
@@ -1,5 +1,6 @@
 import { getOwner } from '@ember/application';
 import ApplicationInstance from '@ember/application/instance';
+import { assert } from '@ember/debug';
 
 import firebase from 'firebase/app';
 
@@ -8,6 +9,8 @@ export default {
 
   create(context: ApplicationInstance): firebase.app.App {
     const config = getOwner(context).resolveRegistration('config:environment');
+    assert('Please set the `firebase` property in your environment config.', config && typeof config.firebase === 'object');
+
     let firebaseApp;
 
     try {

--- a/tests/unit/services/firebase-test.ts
+++ b/tests/unit/services/firebase-test.ts
@@ -10,12 +10,14 @@ module('Unit | Service | firebase', function (hooks) {
 
       // Arrange
       this.owner.register('config:environment', {
-        apiKey: '<api_key>',
-        authDomain: '<auth_domain>',
-        databaseURL: '<database_url>',
-        projectId: '<project_id>',
-        storageBucket: '<storage_bucket>',
-        messagingSenderId: '<messaging_sender_id>',
+        firebase: {
+          apiKey: '<api_key>',
+          authDomain: '<auth_domain>',
+          databaseURL: '<database_url>',
+          projectId: '<project_id>',
+          storageBucket: '<storage_bucket>',
+          messagingSenderId: '<messaging_sender_id>',
+        }
       });
 
       // Act
@@ -24,5 +26,20 @@ module('Unit | Service | firebase', function (hooks) {
       // Assert
       assert.equal(result.name, '[DEFAULT]');
     });
+
+    test('throws an error if the firebase config is not present', function (assert) {
+      assert.expect(1);
+ 
+      // Arrange
+      this.owner.register('config:environment', {
+        firebase: null
+      });
+
+      // Act
+      const result = this.owner.lookup('service:firebase');
+
+      // Assert
+      assert.throws('an error is thrown if no config is present');
+   });
   });
 });


### PR DESCRIPTION
Adds an assert that checks that a firebase config is present so the resulting error is less cryptic (see [this issue](https://github.com/mikkopaderes/ember-cloud-firestore-adapter/issues/177))

If no firebase config exists or if it is not of type "object" this error will be thrown:
```
            Error: Assertion Failed: Please set the `firebase` property in your environment config.
                at assert (http://localhost:7357/assets/vendor.js:36254:15)
                at Object.create (http://localhost:7357/assets/vendor.js:100504:86)
                at FactoryManager.create (http://localhost:7357/assets/vendor.js:1266:25)
                at Proxy.create (http://localhost:7357/assets/vendor.js:980:20)
                at instantiateFactory (http://localhost:7357/assets/vendor.js:1081:71)
                at lookup (http://localhost:7357/assets/vendor.js:1009:12)
                at Container.lookup (http://localhost:7357/assets/vendor.js:874:14)
                at Class.lookup (http://localhost:7357/assets/vendor.js:27112:33)
                at Object.initialize (http://localhost:7357/assets/vendor.js:99200:34)
                at http://localhost:7357/assets/vendor.js:37284:21
```

If firebase config is present but empty or missing items firebase itself will take care of the rest, e.g.
```
            FirebaseError: "projectId" not provided in firebase.initializeApp.
                at new Br (http://localhost:7357/assets/vendor.js:69452:52485)
                at http://localhost:7357/assets/vendor.js:69452:273146
                at Sp.dp (http://localhost:7357/assets/vendor.js:69452:273263)
                at new Sp (http://localhost:7357/assets/vendor.js:69452:279707)
                at ym.instanceFactory (http://localhost:7357/assets/vendor.js:69452:336579)
                at C.getOrInitializeService (http://localhost:7357/assets/vendor.js:349:10320)
                at C.getImmediate (http://localhost:7357/assets/vendor.js:349:7312)
                at $._getService (http://localhost:7357/assets/vendor.js:349:16917)
                at $.n.type.a.<computed> [as firestore] (http://localhost:7357/assets/vendor.js:349:19680)
                at Object.initialize (http://localhost:7357/assets/vendor.js:99201:25)
```